### PR TITLE
feat: Add BlogPost entity and DTO + status as enum

### DIFF
--- a/Backend/src/main/java/dat/config/HibernateConfig.java
+++ b/Backend/src/main/java/dat/config/HibernateConfig.java
@@ -46,7 +46,7 @@ public class HibernateConfig {
         configuration.addAnnotatedClass(PlayerAccount.class);
         configuration.addAnnotatedClass(Team.class);
         configuration.addAnnotatedClass(Tournament.class);
-
+        configuration.addAnnotatedClass(BlogPost.class);
     }
 
     private static EntityManagerFactory createEMF(boolean forTest, String DBName) {

--- a/Backend/src/main/java/dat/dtos/BlogPostDTO.java
+++ b/Backend/src/main/java/dat/dtos/BlogPostDTO.java
@@ -1,0 +1,44 @@
+package dat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dat.entities.BlogPost;
+import dat.enums.BlogPostStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlogPostDTO {
+
+    private Long id;
+
+    private Long userId;
+
+    private String title;
+
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd-MM-yyyy")
+    private LocalDateTime createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd-MM-yyyy")
+    private LocalDateTime updatedAt;
+
+    // Format the enum as a string, might not be necessary/needed
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private BlogPostStatus status;
+
+    public BlogPostDTO(BlogPost blogPost) {
+        this.id = blogPost.getId();
+        this.userId = blogPost.getUserId();
+        this.title = blogPost.getTitle();
+        this.content = blogPost.getContent();
+        this.createdAt = blogPost.getCreatedAt();
+        this.updatedAt = blogPost.getUpdatedAt();
+        this.status = blogPost.getStatus();
+    }
+
+}

--- a/Backend/src/main/java/dat/entities/BlogPost.java
+++ b/Backend/src/main/java/dat/entities/BlogPost.java
@@ -1,0 +1,71 @@
+package dat.entities;
+
+import dat.dtos.BlogPostDTO;
+import dat.enums.BlogPostStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@NamedQueries({
+        @NamedQuery(
+                name = "BlogPost.getAll",
+                query = "SELECT bp FROM BlogPost bp"
+        ),
+        @NamedQuery(
+                name = "BlogPost.findAllSummariesWithPreview",
+                query = "SELECT new dat.dtos.BlogPostDTO(bp.id, bp.userId, bp.title, SUBSTRING(bp.content, 1, 150), bp.createdAt, bp.updatedAt, bp.status) FROM BlogPost bp"
+        )
+})
+@Table(name = "blog_post")
+public class BlogPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, unique = true)
+    private Long id;
+
+    // A user can have multiple blog posts, but a blog post belongs to one user
+    // Who should be responsible for the relation and where should it be managed?
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, length = 5000) // Possibly a different length - maybe use @Lob?
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // Should there be a default, perhaps PENDING_REVIEW or DRAFT?
+    @Enumerated(EnumType.STRING)
+    private BlogPostStatus status;
+
+    public BlogPost(BlogPostDTO blogPostDTO) {
+        this.id = blogPostDTO.getId();
+        this.userId = blogPostDTO.getUserId();
+        this.title = blogPostDTO.getTitle();
+        this.content = blogPostDTO.getContent();
+        this.createdAt = blogPostDTO.getCreatedAt();
+        this.updatedAt = blogPostDTO.getUpdatedAt();
+        this.status = blogPostDTO.getStatus();
+    }
+
+}

--- a/Backend/src/main/java/dat/entities/BlogPost.java
+++ b/Backend/src/main/java/dat/entities/BlogPost.java
@@ -23,7 +23,7 @@ import java.time.LocalDateTime;
                 query = "SELECT bp FROM BlogPost bp"
         ),
         @NamedQuery(
-                name = "BlogPost.findAllSummariesWithPreview",
+                name = "BlogPost.findAllWithOnlyContentPreview",
                 query = "SELECT new dat.dtos.BlogPostDTO(bp.id, bp.userId, bp.title, SUBSTRING(bp.content, 1, 150), bp.createdAt, bp.updatedAt, bp.status) FROM BlogPost bp"
         )
 })

--- a/Backend/src/main/java/dat/enums/BlogPostStatus.java
+++ b/Backend/src/main/java/dat/enums/BlogPostStatus.java
@@ -1,0 +1,8 @@
+package dat.enums;
+
+public enum BlogPostStatus {
+    DRAFT,
+    READY, // to either be saved as draft or published
+    PENDING_REVIEW, // for content review perhaps?
+    PUBLISHED
+}


### PR DESCRIPTION
- Created BlogPost JPA entity and added to HibernateConfig file
- Implemented BlogPostDTO for data transfer
- Created enum to represent blog post status