### PR TITLE
Team F service layer and blog status

### DIFF
--- a/Backend/src/main/java/dat/daos/BlogPostDAO.java
+++ b/Backend/src/main/java/dat/daos/BlogPostDAO.java
@@ -57,14 +57,15 @@ public class BlogPostDAO implements IDAO<BlogPostDTO, Long> {
     public BlogPostDTO create(BlogPostDTO blogPostDTO) {
         try (EntityManager em = emf.createEntityManager()) {
 
-            // If status is not READY, we should not save it,
-            // because the content needs to be checked first
-           /* if (blogPostDTO.getStatus() != BlogPostStatus.READY) {
+            if (blogPostDTO.getStatus() != BlogPostStatus.READY) {
                 throw new IllegalStateException("Blog post is not ready to be saved - it needs to be reviewed.");
-            }*/
+            }
 
             BlogPost newBlogPost = new BlogPost(blogPostDTO);
             // TODO: Set the new status to PUBLISHED or DRAFT depending on the context
+            // Currently we're only able to publish in our given US
+            // We might have to take in status in the param in the future
+            newBlogPost.setStatus(BlogPostStatus.PUBLISHED);
 
             em.getTransaction().begin();
             em.persist(newBlogPost);

--- a/Backend/src/main/java/dat/service/BlogPostService.java
+++ b/Backend/src/main/java/dat/service/BlogPostService.java
@@ -2,23 +2,27 @@ package dat.service;
 
 import dat.daos.BlogPostDAO;
 import dat.dtos.BlogPostDTO;
+import dat.enums.BlogPostStatus;
 import dat.utils.ProfanityFilter;
 
 public class BlogPostService {
 
     private final BlogPostDAO blogPostDAO;
 
-    // yet to be used anywhere
     public BlogPostService(BlogPostDAO blogPostDAO) {
         this.blogPostDAO = blogPostDAO;
     }
 
     public BlogPostDTO createBlogPost(BlogPostDTO blogPostDTO) {
-        if (blogPostDTO != null && !blogPostDTO.getContent().isEmpty()) {
-            if (ProfanityFilter.containsProfanity(blogPostDTO.getContent())) {
-                throw new IllegalStateException("Blogpost contains profanity");
+            if (blogPostDTO == null || blogPostDTO.getContent() == null || blogPostDTO.getContent().isBlank()) {
+                throw new IllegalArgumentException("Blog post content cannot be empty.");
             }
-        }
-        return blogPostDAO.create(blogPostDTO);
+
+            if (ProfanityFilter.containsProfanity(blogPostDTO.getContent())) {
+                throw new IllegalStateException("Blog post contains profanity.");
+            }
+
+            blogPostDTO.setStatus(BlogPostStatus.READY);
+            return blogPostDAO.create(blogPostDTO);
     }
 }

--- a/Backend/src/test/java/US3/dat/utils/ProfanityFilterTest.java
+++ b/Backend/src/test/java/US3/dat/utils/ProfanityFilterTest.java
@@ -1,6 +1,7 @@
-package dat.utils;
+package US3.dat.utils;
 
 import dat.entities.BlogPost;
+import dat.utils.ProfanityFilter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Made minor refactoring changes to controller, service and dao class

Controller:
- fixed code indentation
- changed create method to call service class instead of dao
- cleaner initialization in constructor

Service:
- improved checks for null and empty content in blog posts
- set the status of the blog post to READY before persisting it via the DAO.

DAO:
- uncommented necessary lines to enable exception handling in the create method
- set the blog status to PUBLISHED when created

Test folder:
- moved the utils test under the US3 folder