### PR TITLE
Dev team f functionality to allow saving a post as a draft

### DIFF
--- a/Backend/src/main/java/dat/entities/BlogPost.java
+++ b/Backend/src/main/java/dat/entities/BlogPost.java
@@ -25,7 +25,11 @@ import java.time.LocalDateTime;
         @NamedQuery(
                 name = "BlogPost.findAllWithOnlyContentPreview",
                 query = "SELECT new dat.dtos.BlogPostDTO(bp.id, bp.userId, bp.title, SUBSTRING(bp.content, 1, 150), bp.createdAt, bp.updatedAt, bp.status) FROM BlogPost bp"
-        )
+        ),
+        // New Query for finding drafts by user
+        @NamedQuery(
+                name = "BlogPost.findDraftsByUser",
+                query = "SELECT bp FROM BlogPost bp WHERE bp.userId = :userId AND bp.status = 'DRAFT'")
 })
 @Table(name = "blog_post")
 public class BlogPost {
@@ -55,8 +59,10 @@ public class BlogPost {
     private LocalDateTime updatedAt;
 
     // Should there be a default, perhaps PENDING_REVIEW or DRAFT?
+    // I added DRAFT as default
     @Enumerated(EnumType.STRING)
-    private BlogPostStatus status;
+    @Column(name = "status", nullable = false)
+    private BlogPostStatus status= BlogPostStatus.DRAFT ;
 
     public BlogPost(BlogPostDTO blogPostDTO) {
         this.id = blogPostDTO.getId();
@@ -65,7 +71,8 @@ public class BlogPost {
         this.content = blogPostDTO.getContent();
         this.createdAt = blogPostDTO.getCreatedAt();
         this.updatedAt = blogPostDTO.getUpdatedAt();
-        this.status = blogPostDTO.getStatus();
+        // Set status, default to DRAFT if not provided
+        this.status = blogPostDTO.getStatus() != null ? blogPostDTO.getStatus() : BlogPostStatus.DRAFT;
     }
 
 }

--- a/Backend/src/main/java/dat/routes/BlogRoute.java
+++ b/Backend/src/main/java/dat/routes/BlogRoute.java
@@ -17,6 +17,11 @@ public class BlogRoute {
             get("/preview", blogController::getAllPreview, Role.ANYONE); // This could be admin depending on frontend layout
             get("/{id}",blogController::getById, Role.ANYONE);
             post("/", blogController::create, Role.ANYONE);
+
+
+            // New draft-related routes
+            get("/drafts/me", blogController::getMyDrafts);    // Get my drafts
+            put("/{id}/publish", blogController::publishDraft); // Publish draft
         };
     }
 }


### PR DESCRIPTION
feat: Implement draft saving and user-post relationships

Completed Task 3.1 & 3.2:
- Added draft functionality with DRAFT as default status
- New endpoints:
  * GET /api/blog/drafts/me - List user's drafts  
  * PUT /api/blog/{id}/publish - Publish drafts
- Maintained 1-to-many user-post relationship via userId
- Added ownership verification
- Implemented status validation

Key changes:
- BlogPost entity now has status field (default: DRAFT)
- New draft-specific queries in BlogPostDAO
- Controller handles draft lifecycle
- Existing userId maintains relationship without breaking changes